### PR TITLE
prevent building of libcondure library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ description = "HTTP/WebSocket connection manager"
 repository = "https://github.com/fanout/condure"
 readme = "README.md"
 edition = "2018"
+autobins = false
+
+[[bin]]
+name = "condure"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
As condure contains a src/lib.rs file, cargo by default creates a library called libcondure, which is not useful. Change Cargo.toml so only the binary is built.