### PR TITLE
increase max number of http request and response headers

### DIFF
--- a/src/http1.rs
+++ b/src/http1.rs
@@ -22,7 +22,7 @@ use std::io;
 use std::io::{Read, Write};
 use std::str;
 
-pub const HEADERS_MAX: usize = 32;
+pub const HEADERS_MAX: usize = 64;
 
 const CHUNK_SIZE_MAX: usize = 0xffff;
 const CHUNK_HEADER_SIZE_MAX: usize = 6; // ffff\r\n

--- a/src/zhttppacket.rs
+++ b/src/zhttppacket.rs
@@ -24,7 +24,7 @@ use std::str;
 
 pub const IDS_MAX: usize = 128;
 
-const HEADERS_MAX: usize = 32;
+const HEADERS_MAX: usize = 64;
 
 const EMPTY_BYTES: &[u8] = b"";
 


### PR DESCRIPTION
The current limit of 32 https headers can be exceeded by some clients.
Between built-in headers from browsers and custom headers that may be
added in different places like CloudFlare or Nginx, this limit can be
hit by many clients. This commit increases the limits to 64, which is
much less likely to be reached.